### PR TITLE
Python 3 compatibility

### DIFF
--- a/bayesian_optimization/bayesian_optimization.py
+++ b/bayesian_optimization/bayesian_optimization.py
@@ -333,7 +333,7 @@ class InterleavedREMBOOptimizer(BayesianOptimizer):
                                       *args, **kwargs)
                        for run in range(interleaved_runs)]
         self.rembos = cycle(self.rembos)
-        self.current_rembo = self.rembos.next()
+        self.current_rembo = next(self.rembos)
 
         self.X_ = []
         self.y_ = []
@@ -361,4 +361,4 @@ class InterleavedREMBOOptimizer(BayesianOptimizer):
         self.y_.append(y)
 
         self.current_rembo.update(X, y)
-        self.current_rembo = self.rembos.next()
+        self.current_rembo = next(self.rembos)


### PR DESCRIPTION
Since iter.next() is removed python 3  changing the self.rembos.next to next(self.rembos) makes it usable on python 3 too.